### PR TITLE
Fix meetup.com URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Functional**Programming**Wroclaw**(https://www.meetup.com/pl-PL/Functional-Programming-Wroclaw)**resources
+Functional Programming Wroclaw (https://www.meetup.com/Functional-Programming-Wroclaw/) resources
 ======================================================================================================
 
 https://wiki.haskell.org/Haskell_logos


### PR DESCRIPTION
In the current version, the link doesn't point to where it should be.